### PR TITLE
Don't hardcode vt1

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -34,7 +34,6 @@
 
 
 static char displayname[256] = ":0";   /* ":0" */
-static int tty = 1; /* tty1 */
 
 static pthread_mutex_t notify_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t notify_condition = PTHREAD_COND_INITIALIZER;
@@ -57,7 +56,6 @@ int main(int argc, char **argv)
 	struct sigaction usr1;
 	char *xserver = NULL;
 	int ret;
-	char vt[80];
 	char xorg_log[PATH_MAX];
 	struct stat statbuf;
 	char *ptrs[32];
@@ -134,9 +132,6 @@ int main(int argc, char **argv)
 
 	for (i = 1; i < argc; i++)
 		ptrs[++count] = strdup(argv[i]);
-
-	snprintf(vt, 80, "vt%d", tty);
-	ptrs[++count] = vt;
 
 	for (i = 0; i <= count; i++) {
 		strncat(all, ptrs[i], PATH_MAX - strlen(all) - 1);

--- a/xorg.service.in
+++ b/xorg.service.in
@@ -17,7 +17,7 @@ Before=xorg.target
 
 [Service]
 Type=forking
-ExecStart=@prefix@/bin/xorg-launch-helper
+ExecStart=@prefix@/bin/xorg-launch-helper vt1
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
Hi,

I like to keep my vt1 clean from gettys and xorgs so I can always go back and see whatever systemd was spewing out during boot.
This is the minimal change that allows me to override the xorg.service file and change the vt xorg is started on.
