### PR TITLE
dev/auto-args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ src/Makefile.in
 src/main.o
 src/xorg-launch-helper
 stamp-h1
-xorg.service
+xorg@.service
 xorg.target
 xorg-launch-helper-*.tar.*

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Auke Kok <auke-jan.h.kok@intel.com>
 Arjan van de Ven <arjan@linux.intel.com>
+Ben Boeckel <mathstuf@gmail.com>

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 EXTRA_DIST = AUTHORS COPYING INSTALL
 
 systemduserunitdir = @SYSTEMD_USERUNITDIR@
-systemduserunit_DATA = xorg.service xorg.target
+systemduserunit_DATA = xorg@.service xorg.target
 
 systemduserunit-install-hook:
 	mkdir -p $(DESTDIR)$(systemduserunitdir)/xorg.target.wants

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_FUNC_FORK
 AC_CHECK_FUNCS([clock_gettime memset strdup])
 
 AC_OUTPUT([
-xorg.service
+xorg@.service
 xorg.target
 ])
 

--- a/src/main.c
+++ b/src/main.c
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	fprintf(stderr, "Starting Xorg server with: \"%s\"", all);
+	fprintf(stderr, "Starting Xorg server with: \"%s\"\n", all);
 	execv(ptrs[0], ptrs);
 	fprintf(stderr, "Failed to execv() the X server.\n");
 

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
  * Authors:
  *     Auke Kok <auke@linux.intel.com>
  *     Arjan van de Ven <arjan@linux.intel.com>
+ *     Ben Boeckel <mathstuf@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/xorg.service.in
+++ b/xorg.service.in
@@ -17,7 +17,7 @@ Before=xorg.target
 
 [Service]
 Type=notify
-ExecStart=@prefix@/bin/xorg-launch-helper :0 -nolisten tcp -noreset vt1
+ExecStart=@prefix@/bin/xorg-launch-helper :0 -nolisten tcp -noreset
 Restart=always
 RestartSec=10
 

--- a/xorg@.service.in
+++ b/xorg@.service.in
@@ -17,6 +17,7 @@ Before=xorg.target
 
 [Service]
 Type=notify
+StandardInput=tty-force
 ExecStart=@prefix@/bin/xorg-launch-helper %i -nolisten tcp -noreset
 ExecStartPost=/usr/bin/systemctl --user set-environment DISPLAY=%i
 ExecStop=/usr/bin/systemctl --user unset-environment DISPLAY

--- a/xorg@.service.in
+++ b/xorg@.service.in
@@ -18,6 +18,8 @@ Before=xorg.target
 [Service]
 Type=notify
 ExecStart=@prefix@/bin/xorg-launch-helper %i -nolisten tcp -noreset
+ExecStartPost=/usr/bin/systemctl --user set-environment DISPLAY=%i
+ExecStop=/usr/bin/systemctl --user unset-environment DISPLAY
 Restart=always
 RestartSec=10
 

--- a/xorg@.service.in
+++ b/xorg@.service.in
@@ -17,7 +17,7 @@ Before=xorg.target
 
 [Service]
 Type=notify
-ExecStart=@prefix@/bin/xorg-launch-helper :0 -nolisten tcp -noreset
+ExecStart=@prefix@/bin/xorg-launch-helper %i -nolisten tcp -noreset
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
startx is able to determine a default for the display and vt. Since this is pretty much a replacement for systemd setups, it should be able to figure it out as well.

One known issue is that it seems as if the vt cannot be taken over properly for some reason (I'm unsure of how startx is able to take it over, so maybe some extra magic is necessary).
